### PR TITLE
refactor: fix issues to work in production

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -1,0 +1,8 @@
+# https://platform.openai.com/api-keys
+OPENAI_API_KEY=
+
+# https://dash.cloudflare.com/
+CLOUDFLARE_ACCOUNT_ID=
+
+# https://developers.cloudflare.com/workers-ai/get-started/rest-api/
+CLOUDFLARE_WORKERSAI_API_TOKEN=

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ logs
 .env
 .env.*
 !.env.example
+
+# Wrangler
+.wrangler

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ logs
 
 # Wrangler
 .wrangler
+.dev.vars

--- a/README.md
+++ b/README.md
@@ -4,22 +4,28 @@ Look at the [Nuxt 3 documentation](https://nuxt.com/docs/getting-started/introdu
 
 ## Setup
 
+1. Install dependencies:
+
 ```bash
-# npm
 npm install
-
-# pnpm
-pnpm install
-
-# yarn
-yarn install
-
-# bun
-bun install
 ```
 
-## Vectorize
+2. Create vectorize
 
-Run `npx wrangler vectorize create langchain_js_nuxt --dimensions 768 --metric cosine`
+```bash
+npx wrangler vectorize create langchain_js_nuxt --dimensions 768 --metric cosine
+```
 
-Start with `npm run pages:dev`.
+3. Copy `.dev.vars.example` to `.dev.vars` and fill in the tokens
+
+4. Build project
+
+```bash
+npm run build
+```
+
+5. Start in preview mode
+
+```bash
+npm run preview
+```

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -7,6 +7,9 @@ export default defineNuxtConfig({
   build: {
     transpile: ['vuetify'],
   },
+  nitro: {
+    minify: false // Useful for debugging
+  },
   css: ["~/assets/css/style.css"],
   modules: [
     (_options, nuxt) => {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -11,7 +11,7 @@ export default defineNuxtConfig({
     // Useful for debugging
     minify: false,
     commands: {
-      preview: 'npx wrangler dev ./server/index.mjs --site ./public --remote'
+      preview: 'npx wrangler dev ./server/index.mjs --site ./public --remote --port 3000'
     }
   },
   css: ["~/assets/css/style.css"],

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -8,7 +8,11 @@ export default defineNuxtConfig({
     transpile: ['vuetify'],
   },
   nitro: {
-    minify: false // Useful for debugging
+    // Useful for debugging
+    minify: false,
+    commands: {
+      preview: 'npx wrangler dev ./server/index.mjs --site ./public --remote'
+    }
   },
   css: ["~/assets/css/style.css"],
   modules: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -119,30 +119,30 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.23.2",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.2.tgz",
-      "integrity": "sha512-0S9TQMmDHlqAZ2ITT95irXKfxN9bncq8ZCoJhun3nHL/lLUxd2NKBJYoNGWH7S0hz6fRQwWlAWn/ILM0C70KZQ==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.3.tgz",
+      "integrity": "sha512-BmR4bWbDIoFJmJ9z2cZ8Gmm2MXgEDgjdWgpKmKWUt54UGFJdlj31ECtbaDvCG/qVdG3AQ1SfpZEs01lUFbzLOQ==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.23.2",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.2.tgz",
-      "integrity": "sha512-n7s51eWdaWZ3vGT2tD4T7J6eJs3QoBXydv7vkUM06Bf1cbVD2Kc2UrkzhiQwobfV7NwOnQXYL7UBJ5VPU+RGoQ==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.3.tgz",
+      "integrity": "sha512-Jg+msLuNuCJDyBvFv5+OKOUjWMZgd85bKjbICd3zWrKAo+bJ49HJufi7CQE0q0uR8NGyO6xkCACScNqyjHSZew==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.22.13",
-        "@babel/generator": "^7.23.0",
+        "@babel/generator": "^7.23.3",
         "@babel/helper-compilation-targets": "^7.22.15",
-        "@babel/helper-module-transforms": "^7.23.0",
+        "@babel/helper-module-transforms": "^7.23.3",
         "@babel/helpers": "^7.23.2",
-        "@babel/parser": "^7.23.0",
+        "@babel/parser": "^7.23.3",
         "@babel/template": "^7.22.15",
-        "@babel/traverse": "^7.23.2",
-        "@babel/types": "^7.23.0",
+        "@babel/traverse": "^7.23.3",
+        "@babel/types": "^7.23.3",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -167,12 +167,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
-      "integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.3.tgz",
+      "integrity": "sha512-keeZWAV4LU3tW0qRi19HRpabC/ilM0HRBBzf9/k8FFiG4KVpiv0FIy4hHfLfFQZNhziCTPTmd59zoyv6DNISzg==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.23.0",
+        "@babel/types": "^7.23.3",
         "@jridgewell/gen-mapping": "^0.3.2",
         "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
@@ -309,9 +309,9 @@
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.0.tgz",
-      "integrity": "sha512-WhDWw1tdrlT0gMgUJSlX0IQvoO1eN279zrAUbVB+KpV2c3Tylz8+GnKOLllCS6Z/iZQEyVYxhZVUdPTqs2YYPw==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.3.tgz",
+      "integrity": "sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==",
       "dev": true,
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.22.20",
@@ -504,9 +504,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
-      "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.3.tgz",
+      "integrity": "sha512-uVsWNvlVsIninV2prNz/3lHCb+5CJ+e+IUBfbjToAHODtfGYLfCFuY4AU7TskI+dAKk+njsPiBjq1gKTvZOBaw==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -516,16 +516,16 @@
       }
     },
     "node_modules/@babel/plugin-proposal-decorators": {
-      "version": "7.23.2",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.23.2.tgz",
-      "integrity": "sha512-eR0gJQc830fJVGz37oKLvt9W9uUIQSAovUl0e9sJ3YeO09dlcoBVYD3CLrjCj4qHdXmfiyTyFt8yeQYSN5fxLg==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.23.3.tgz",
+      "integrity": "sha512-u8SwzOcP0DYSsa++nHd/9exlHb0NAlHCb890qtZZbSwPX2bFv8LBEztxwN7Xg/dS8oAFFidhrI9PBcLBJSkGRQ==",
       "dev": true,
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.22.15",
         "@babel/helper-plugin-utils": "^7.22.5",
         "@babel/helper-replace-supers": "^7.22.20",
         "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/plugin-syntax-decorators": "^7.22.10"
+        "@babel/plugin-syntax-decorators": "^7.23.3"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -535,9 +535,9 @@
       }
     },
     "node_modules/@babel/plugin-syntax-decorators": {
-      "version": "7.22.10",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.22.10.tgz",
-      "integrity": "sha512-z1KTVemBjnz+kSEilAsI4lbkPOl5TvJH7YDSY1CTIzvLWJ+KHXp+mRe8VPmfnyvqOPqar1V2gid2PleKzRUstQ==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.23.3.tgz",
+      "integrity": "sha512-cf7Niq4/+/juY67E0PbgH0TDhLQ5J7zS8C/Q5FFx+DWyrRa9sUQdTXkjqKu8zGvuqr7vw1muKiukseihU+PJDA==",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5"
@@ -550,9 +550,9 @@
       }
     },
     "node_modules/@babel/plugin-syntax-import-attributes": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.22.5.tgz",
-      "integrity": "sha512-KwvoWDeNKPETmozyFE0P2rOLqh39EoQHNjqizrI5B8Vt0ZNS7M56s7dAiAqbYfiAYOuIzIh96z3iR2ktgu3tEg==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.23.3.tgz",
+      "integrity": "sha512-pawnE0P9g10xgoP7yKr6CK63K2FMsTE+FZidZO/1PwRdzmAPVs+HS1mAURUsgaoxammTJvULUdIkEK0gOcU2tA==",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5"
@@ -577,9 +577,9 @@
       }
     },
     "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.22.5.tgz",
-      "integrity": "sha512-gvyP4hZrgrs/wWMaocvxZ44Hw0b3W8Pe+cMxc8V1ULQ07oh8VNbIRaoD1LRZVTvD+0nieDKjfgKg89sD7rrKrg==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.23.3.tgz",
+      "integrity": "sha512-EB2MELswq55OHUoRZLGg/zC7QWUKfNLpE57m/S2yr1uEneIgsTgrSzXP3NXEsMkVn76OlaVVnzN+ugObuYGwhg==",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5"
@@ -592,9 +592,9 @@
       }
     },
     "node_modules/@babel/plugin-syntax-typescript": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.22.5.tgz",
-      "integrity": "sha512-1mS2o03i7t1c6VzH6fdQ3OA8tcEIxwG18zIPRp+UY1Ihv6W+XZzBCVxExF9upussPXJ0xE9XRHwMoNs1ep/nRQ==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.23.3.tgz",
+      "integrity": "sha512-9EiNjVJOMwCO+43TqoTrgQ8jMwcAd0sWyXi9RPfIsLTj4R2MADDDQXELhffaUx/uJv2AYcxBgPwH6j4TIA4ytQ==",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5"
@@ -607,15 +607,15 @@
       }
     },
     "node_modules/@babel/plugin-transform-typescript": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.22.15.tgz",
-      "integrity": "sha512-1uirS0TnijxvQLnlv5wQBwOX3E1wCFX7ITv+9pBV2wKEk4K+M5tqDaoNXnTH8tjEIYHLO98MwiTWO04Ggz4XuA==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.23.3.tgz",
+      "integrity": "sha512-ogV0yWnq38CFwH20l2Afz0dfKuZBx9o/Y2Rmh5vuSS0YD1hswgEgTfyTzuSrT2q9btmHRSqYoSfwFUVaC1M1Jw==",
       "dev": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.22.5",
         "@babel/helper-create-class-features-plugin": "^7.22.15",
         "@babel/helper-plugin-utils": "^7.22.5",
-        "@babel/plugin-syntax-typescript": "^7.22.5"
+        "@babel/plugin-syntax-typescript": "^7.23.3"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -625,9 +625,9 @@
       }
     },
     "node_modules/@babel/standalone": {
-      "version": "7.23.2",
-      "resolved": "https://registry.npmjs.org/@babel/standalone/-/standalone-7.23.2.tgz",
-      "integrity": "sha512-VJNw7OS26JvB6rE9XpbT6uQeQIEBWU5eeHGS4VR/+/4ZoKdLBXLcy66ZVJ/9IBkK1RMp8B0cohvhzdKWtJAGmg==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/standalone/-/standalone-7.23.3.tgz",
+      "integrity": "sha512-ZfB6wyLVqr9ANl1F0l/0aqoNUE1/kcWlQHmk0wF9OTEKDK1whkXYLruRMt53zY556yS2+84EsOpr1hpjZISTRg==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -648,19 +648,19 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.23.2",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
-      "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.3.tgz",
+      "integrity": "sha512-+K0yF1/9yR0oHdE0StHuEj3uTPzwwbrLGfNOndVJVV2TqA5+j3oljJUb4nmB954FLGjNem976+B+eDuLIjesiQ==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.22.13",
-        "@babel/generator": "^7.23.0",
+        "@babel/generator": "^7.23.3",
         "@babel/helper-environment-visitor": "^7.22.20",
         "@babel/helper-function-name": "^7.23.0",
         "@babel/helper-hoist-variables": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.23.0",
-        "@babel/types": "^7.23.0",
+        "@babel/parser": "^7.23.3",
+        "@babel/types": "^7.23.3",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -669,9 +669,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
-      "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.3.tgz",
+      "integrity": "sha512-OZnvoH2l8PK5eUvEcUyCt/sXgr/h+UWpVuBbOljwcrAgUl6lpchoQ++PHGyQy1AtYnVA6CEq3y5xeEI10brpXw==",
       "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.22.5",
@@ -1158,9 +1158,9 @@
       }
     },
     "node_modules/@fastify/busboy": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.0.0.tgz",
-      "integrity": "sha512-JUFJad5lv7jxj926GPgymrWQxxjPYuJNiNjNMzqT+HiuP6Vl3dk5xzG+8sTX96np0ZAluvaMzPsjhHZ5rNuNQQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.0.tgz",
+      "integrity": "sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA==",
       "dev": true,
       "engines": {
         "node": ">=14"
@@ -1392,12 +1392,12 @@
       "integrity": "sha512-SWxvzRbUQRfewlIV+OF4/YF4DkeTjMWoT8Hh9yeU/5UBVdJZj9Uf4a9+cXjknSIhIaMxZ/4N1O/s7ojApOOGjg=="
     },
     "node_modules/@netlify/functions": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@netlify/functions/-/functions-2.3.0.tgz",
-      "integrity": "sha512-E3kzXPWMP/r1rAWhjTaXcaOT47dhEvg/eQUJjRLhD9Zzp0WqkdynHr+bqff4rFNv6tuXrtFZrpbPJFKHH0c0zw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@netlify/functions/-/functions-2.4.0.tgz",
+      "integrity": "sha512-dIqhdj5u4Lu/8qbYwtYpn8NfvIyPHbSTV2lAP4ocL+iwC9As06AXT0wa/xOpO2vRWJa0IMxdZaqCPnkyHlHiyg==",
       "dev": true,
       "dependencies": {
-        "@netlify/serverless-functions-api": "1.9.0",
+        "@netlify/serverless-functions-api": "1.11.0",
         "is-promise": "^4.0.0"
       },
       "engines": {
@@ -1414,9 +1414,9 @@
       }
     },
     "node_modules/@netlify/serverless-functions-api": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@netlify/serverless-functions-api/-/serverless-functions-api-1.9.0.tgz",
-      "integrity": "sha512-Jq4uk1Mwa5vyxImupJYXPP+I5yYcp3PtguvXtJRutKdm9DPALXfZVtCQzBWMNdZiqVWCM3La9hvaBsPjSMfeug==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@netlify/serverless-functions-api/-/serverless-functions-api-1.11.0.tgz",
+      "integrity": "sha512-3splAsr2CekL7VTwgo6yTvzD2+f269/s+TJafYazonqMNNo31yzvFxD5HpLtni4DNE1ppymVKZ4X/rLN3yl0vQ==",
       "dev": true,
       "dependencies": {
         "@netlify/node-cookies": "^0.1.0",
@@ -1478,10 +1478,13 @@
       }
     },
     "node_modules/@npmcli/agent/node_modules/lru-cache": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.1.tgz",
-      "integrity": "sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.2.tgz",
+      "integrity": "sha512-Yj9mA8fPiVgOUpByoTZO5pNrcl5Yk37FcSHsUINpAsaBIEZIuqcCclDZJCVxqQShDsmYX8QG63svJiTbOATZwg==",
       "dev": true,
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
       "engines": {
         "node": "14 || >=16.14"
       }
@@ -1527,10 +1530,13 @@
       }
     },
     "node_modules/@npmcli/git/node_modules/lru-cache": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.1.tgz",
-      "integrity": "sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.2.tgz",
+      "integrity": "sha512-Yj9mA8fPiVgOUpByoTZO5pNrcl5Yk37FcSHsUINpAsaBIEZIuqcCclDZJCVxqQShDsmYX8QG63svJiTbOATZwg==",
       "dev": true,
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
       "engines": {
         "node": "14 || >=16.14"
       }
@@ -1658,32 +1664,31 @@
       "dev": true
     },
     "node_modules/@nuxt/devtools": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@nuxt/devtools/-/devtools-1.0.0.tgz",
-      "integrity": "sha512-pM5AvystXlFPYOsGbH8PBxEYkttiEWHsZnGw660iMw8QedB6mAweT21XX9LDS69cqnRY5uTFqVOmO9Y4EYL3hg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@nuxt/devtools/-/devtools-1.0.2.tgz",
+      "integrity": "sha512-nfqvRc36Sh20gDVs3pViHvcyyz3NmaNqgJnWUXgfjSCsT7G/p2wHsoNUXYYTF7kpk3kbNusftaWrIzAiTiXC9A==",
       "dev": true,
       "dependencies": {
         "@antfu/utils": "^0.7.6",
-        "@nuxt/devtools-kit": "1.0.0",
-        "@nuxt/devtools-wizard": "1.0.0",
-        "@nuxt/kit": "^3.7.4",
+        "@nuxt/devtools-kit": "1.0.2",
+        "@nuxt/devtools-wizard": "1.0.2",
+        "@nuxt/kit": "^3.8.1",
         "birpc": "^0.2.14",
         "consola": "^3.2.3",
-        "destr": "^2.0.1",
+        "destr": "^2.0.2",
         "error-stack-parser-es": "^0.1.1",
         "execa": "^7.2.0",
-        "fast-glob": "^3.3.1",
+        "fast-glob": "^3.3.2",
         "flatted": "^3.2.9",
         "get-port-please": "^3.1.1",
-        "global-dirs": "^3.0.1",
         "h3": "^1.8.2",
         "hookable": "^5.5.3",
-        "image-meta": "^0.1.1",
-        "is-installed-globally": "^0.4.0",
+        "image-meta": "^0.2.0",
+        "is-installed-globally": "^1.0.0",
         "launch-editor": "^2.6.1",
         "local-pkg": "^0.5.0",
-        "magicast": "^0.3.0",
-        "nitropack": "^2.6.3",
+        "magicast": "^0.3.2",
+        "nitropack": "^2.7.2",
         "nypm": "^0.3.3",
         "ofetch": "^1.3.3",
         "ohash": "^1.1.3",
@@ -1696,8 +1701,8 @@
         "semver": "^7.5.4",
         "simple-git": "^3.20.0",
         "sirv": "^2.0.3",
-        "unimport": "^3.4.0",
-        "vite-plugin-inspect": "^0.7.40",
+        "unimport": "^3.5.0",
+        "vite-plugin-inspect": "^0.7.42",
         "vite-plugin-vue-inspector": "^4.0.0",
         "which": "^3.0.1",
         "ws": "^8.14.2"
@@ -1706,36 +1711,36 @@
         "devtools": "cli.mjs"
       },
       "peerDependencies": {
-        "nuxt": "^3.7.4",
+        "nuxt": "^3.8.1",
         "vite": "*"
       }
     },
     "node_modules/@nuxt/devtools-kit": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@nuxt/devtools-kit/-/devtools-kit-1.0.0.tgz",
-      "integrity": "sha512-cNloBepQYCBW6x/ctfCvyYRZudxhfgh5w5JDswpCzn7KXmm8U6abG2jyT0FXIaceW1d5QYMpGCN1RUw24wSvOA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@nuxt/devtools-kit/-/devtools-kit-1.0.2.tgz",
+      "integrity": "sha512-iFi54NNCcPsF/jW14HbRlq3aOClOWdfiein0CvKoQ5shobHgn1s3xULh8o9QPKI2oTarcuJL+EFIK43CwfoXyw==",
       "dev": true,
       "dependencies": {
-        "@nuxt/kit": "^3.7.4",
-        "@nuxt/schema": "^3.7.4",
+        "@nuxt/kit": "^3.8.1",
+        "@nuxt/schema": "^3.8.1",
         "execa": "^7.2.0"
       },
       "peerDependencies": {
-        "nuxt": "^3.7.4",
+        "nuxt": "^3.8.1",
         "vite": "*"
       }
     },
     "node_modules/@nuxt/devtools-wizard": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@nuxt/devtools-wizard/-/devtools-wizard-1.0.0.tgz",
-      "integrity": "sha512-9OeZM2/Y4VuI06gdlDjmYM8yUzdfnywy4t2u2VAEfA2Lk7vk3U1lYn51IAqr+Gits9tp/Q9OiktMWmPLLNGgFw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@nuxt/devtools-wizard/-/devtools-wizard-1.0.2.tgz",
+      "integrity": "sha512-fY9Y0eCJG7eSuUgnjImWVfLZPZymoHxjrVsdhfKs3yRJvB2siaabluxvdy2OTYc+WpIxuey0hjqpv+dVtnYw1A==",
       "dev": true,
       "dependencies": {
         "consola": "^3.2.3",
         "diff": "^5.1.0",
         "execa": "^7.2.0",
-        "global-dirs": "^3.0.1",
-        "magicast": "^0.3.0",
+        "global-directory": "^4.0.1",
+        "magicast": "^0.3.2",
         "pathe": "^1.1.1",
         "pkg-types": "^1.0.3",
         "prompts": "^2.4.2",
@@ -1747,19 +1752,19 @@
       }
     },
     "node_modules/@nuxt/kit": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.8.0.tgz",
-      "integrity": "sha512-oIthQxeMIVs4ESVP5FqLYn8tj0S1sLd+eYreh+dNYgnJ2pTi7+THR12ONBNHjk668jqEe7ErUJ8UlGwqBzgezg==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.8.1.tgz",
+      "integrity": "sha512-DrhG1Z85iH68QOTkgfb0HVfM2g7+CfcMWrFWMDwck9ofyM2RXQUZyfmvMedwBnui1AjjpgpLO9078yZM+RqNUg==",
       "dev": true,
       "dependencies": {
-        "@nuxt/schema": "3.8.0",
+        "@nuxt/schema": "3.8.1",
         "c12": "^1.5.1",
         "consola": "^3.2.3",
-        "defu": "^6.1.2",
+        "defu": "^6.1.3",
         "globby": "^13.2.2",
         "hash-sum": "^2.0.0",
         "ignore": "^5.2.4",
-        "jiti": "^1.20.0",
+        "jiti": "^1.21.0",
         "knitwork": "^1.0.0",
         "mlly": "^1.4.2",
         "pathe": "^1.1.1",
@@ -1776,18 +1781,17 @@
       }
     },
     "node_modules/@nuxt/schema": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@nuxt/schema/-/schema-3.8.0.tgz",
-      "integrity": "sha512-VEDVeCjdVowhoY5vIBSz94+SSwmM204jN6TNe/ShBJ2d/vZiy9EtLbhOwqaPNFHwnN1fl/XFHThwJiexdB9D1w==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@nuxt/schema/-/schema-3.8.1.tgz",
+      "integrity": "sha512-fSaWRcI/2mUskfTZTGSnH6Ny0x05CRzylbVn6WFV0d6UEKIVy42Qd6n+h7yoFfp4cq4nji6u16PT4SqS1DEhsw==",
       "dev": true,
       "dependencies": {
         "@nuxt/ui-templates": "^1.3.1",
         "consola": "^3.2.3",
-        "defu": "^6.1.2",
+        "defu": "^6.1.3",
         "hookable": "^5.5.3",
         "pathe": "^1.1.1",
         "pkg-types": "^1.0.3",
-        "postcss-import-resolver": "^2.0.0",
         "std-env": "^3.4.3",
         "ufo": "^1.3.1",
         "unimport": "^3.4.0",
@@ -1847,20 +1851,20 @@
       "dev": true
     },
     "node_modules/@nuxt/vite-builder": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@nuxt/vite-builder/-/vite-builder-3.8.0.tgz",
-      "integrity": "sha512-F9BfH+c/Idp6sBGVHR4QJSuoO42evtE4D0OelD45NgkqVvmBmOawlj0Oz5fDKoV64LDPI2+yE+xnBdQtsNv/VA==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@nuxt/vite-builder/-/vite-builder-3.8.1.tgz",
+      "integrity": "sha512-Ot/twGONxj22T9U4bxp771ibKVFlZxIiYDHY/e6mZsE4Blc0efKo6MzPPPo0W4/tXQbtKKEq41uINN3dMI3mag==",
       "dev": true,
       "dependencies": {
-        "@nuxt/kit": "3.8.0",
-        "@rollup/plugin-replace": "^5.0.4",
+        "@nuxt/kit": "3.8.1",
+        "@rollup/plugin-replace": "^5.0.5",
         "@vitejs/plugin-vue": "^4.4.0",
         "@vitejs/plugin-vue-jsx": "^3.0.2",
         "autoprefixer": "^10.4.16",
         "clear": "^0.1.0",
         "consola": "^3.2.3",
         "cssnano": "^6.0.1",
-        "defu": "^6.1.2",
+        "defu": "^6.1.3",
         "esbuild": "^0.19.5",
         "escape-string-regexp": "^5.0.0",
         "estree-walker": "^3.0.3",
@@ -1876,8 +1880,6 @@
         "perfect-debounce": "^1.0.0",
         "pkg-types": "^1.0.3",
         "postcss": "^8.4.31",
-        "postcss-import": "^15.1.0",
-        "postcss-url": "^10.1.3",
         "rollup-plugin-visualizer": "^5.9.2",
         "std-env": "^3.4.3",
         "strip-literal": "^1.3.0",
@@ -2509,42 +2511,57 @@
         "node": "^16.14.0 || >=18.0.0"
       }
     },
+    "node_modules/@tufjs/models/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@types/estree": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.4.tgz",
-      "integrity": "sha512-2JwWnHK9H+wUZNorf2Zr6ves96WHoWDJIftkcxPKsS7Djta6Zu519LarhRNljPXkpsZR2ZMwNCPeW7omW07BJw==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
       "dev": true
     },
     "node_modules/@types/http-proxy": {
-      "version": "1.17.13",
-      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.13.tgz",
-      "integrity": "sha512-GkhdWcMNiR5QSQRYnJ+/oXzu0+7JJEPC8vkWXK351BkhjraZF+1W13CUYARUvX9+NqIU2n6YHA4iwywsc/M6Sw==",
+      "version": "1.17.14",
+      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.14.tgz",
+      "integrity": "sha512-SSrD0c1OQzlFX7pGu1eXxSEjemej64aaNPRhhVYUGqXh0BtldAAx37MG8btcumvpgKyZp1F5Gn3JkktdxiFv6w==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/node": {
-      "version": "18.18.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.8.tgz",
-      "integrity": "sha512-OLGBaaK5V3VRBS1bAkMVP2/W9B+H8meUfl866OrMNQqt7wDgdpWPp5o6gmIc9pB+lIQHSq4ZL8ypeH1vPxcPaQ==",
+      "version": "18.18.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.9.tgz",
+      "integrity": "sha512-0f5klcuImLnG4Qreu9hPj/rEfFq6YRc5n2mAjSsH+ec/mJL+3voBH0+8T7o8RpFjH7ovc+TRsL/c7OYIQsPTfQ==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
     },
     "node_modules/@types/node-fetch": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.8.tgz",
-      "integrity": "sha512-nnH5lV9QCMPsbEVdTb5Y+F3GQxLSw1xQgIydrb2gSfEavRPs50FnMr+KUaa+LoPSqibm2N+ZZxH7lavZlAT4GA==",
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.9.tgz",
+      "integrity": "sha512-bQVlnMLFJ2d35DkPNjEPmd9ueO/rh5EiaZt2bhqiSarPjZIuIV6bPQVqcrEyvNo+AfTrRGVazle1tl597w3gfA==",
       "dependencies": {
         "@types/node": "*",
         "form-data": "^4.0.0"
       }
     },
     "node_modules/@types/node-forge": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.8.tgz",
-      "integrity": "sha512-vGXshY9vim9CJjrpcS5raqSjEfKlJcWy2HNdgUasR66fAnVEYarrf1ULV4nfvpC1nZq/moA9qyqBcu83x+Jlrg==",
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.9.tgz",
+      "integrity": "sha512-meK88cx/sTalPSLSoCzkiUB4VPIFHmxtXm5FaaqRDqBX2i/Sy8bJ4odsan0b20RBjPh06dAQ+OTTdnyQyhJZyQ==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -2562,9 +2579,9 @@
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="
     },
     "node_modules/@types/uuid": {
-      "version": "9.0.6",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.6.tgz",
-      "integrity": "sha512-BT2Krtx4xaO6iwzwMFUYvWBWkV2pr37zD68Vmp1CDV196MzczBRxuEpD6Pr395HAgebC/co7hOphs53r8V7jew=="
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.7.tgz",
+      "integrity": "sha512-WUtIVRUZ9i5dYXefDEAI7sh9/O7jGvHg7Df/5O/gtH3Yabe5odI3UWopVR1qbPXQtvOxWu3mM4XxlYeZtMWF4g=="
     },
     "node_modules/@unhead/dom": {
       "version": "1.8.3",
@@ -2716,9 +2733,9 @@
       }
     },
     "node_modules/@vitejs/plugin-vue": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-4.4.0.tgz",
-      "integrity": "sha512-xdguqb+VUwiRpSg+nsc2HtbAUSGak25DXYvpQQi4RVU1Xq1uworyoH/md9Rfd8zMmPR/pSghr309QNcftUVseg==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-4.4.1.tgz",
+      "integrity": "sha512-HCQG8VDFDM7YDAdcj5QI5DvUi+r6xvo9LgvYdk7LSkUNwdpempdB5horkMSZsbdey9Ywsf5aaU8kEPw9M5kREA==",
       "dev": true,
       "engines": {
         "node": "^14.18.0 || >=16.0.0"
@@ -2810,39 +2827,39 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.7.tgz",
-      "integrity": "sha512-pACdY6YnTNVLXsB86YD8OF9ihwpolzhhtdLVHhBL6do/ykr6kKXNYABRtNMGrsQXpEXXyAdwvWWkuTbs4MFtPQ==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.8.tgz",
+      "integrity": "sha512-hN/NNBUECw8SusQvDSqqcVv6gWq8L6iAktUR0UF3vGu2OhzRqcOiAno0FmBJWwxhYEXRlQJT5XnoKsVq1WZx4g==",
       "dev": true,
       "dependencies": {
         "@babel/parser": "^7.23.0",
-        "@vue/shared": "3.3.7",
+        "@vue/shared": "3.3.8",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.0.2"
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.3.7.tgz",
-      "integrity": "sha512-0LwkyJjnUPssXv/d1vNJ0PKfBlDoQs7n81CbO6Q0zdL7H1EzqYRrTVXDqdBVqro0aJjo/FOa1qBAPVI4PGSHBw==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.3.8.tgz",
+      "integrity": "sha512-+PPtv+p/nWDd0AvJu3w8HS0RIm/C6VGBIRe24b9hSyNWOAPEUosFZ5diwawwP8ip5sJ8n0Pe87TNNNHnvjs0FQ==",
       "dev": true,
       "dependencies": {
-        "@vue/compiler-core": "3.3.7",
-        "@vue/shared": "3.3.7"
+        "@vue/compiler-core": "3.3.8",
+        "@vue/shared": "3.3.8"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.3.7.tgz",
-      "integrity": "sha512-7pfldWy/J75U/ZyYIXRVqvLRw3vmfxDo2YLMwVtWVNew8Sm8d6wodM+OYFq4ll/UxfqVr0XKiVwti32PCrruAw==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.3.8.tgz",
+      "integrity": "sha512-WMzbUrlTjfYF8joyT84HfwwXo+8WPALuPxhy+BZ6R4Aafls+jDBnSz8PDz60uFhuqFbl3HxRfxvDzrUf3THwpA==",
       "dev": true,
       "dependencies": {
         "@babel/parser": "^7.23.0",
-        "@vue/compiler-core": "3.3.7",
-        "@vue/compiler-dom": "3.3.7",
-        "@vue/compiler-ssr": "3.3.7",
-        "@vue/reactivity-transform": "3.3.7",
-        "@vue/shared": "3.3.7",
+        "@vue/compiler-core": "3.3.8",
+        "@vue/compiler-dom": "3.3.8",
+        "@vue/compiler-ssr": "3.3.8",
+        "@vue/reactivity-transform": "3.3.8",
+        "@vue/shared": "3.3.8",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.30.5",
         "postcss": "^8.4.31",
@@ -2850,13 +2867,13 @@
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.3.7.tgz",
-      "integrity": "sha512-TxOfNVVeH3zgBc82kcUv+emNHo+vKnlRrkv8YvQU5+Y5LJGJwSNzcmLUoxD/dNzv0bhQ/F0s+InlgV0NrApJZg==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.3.8.tgz",
+      "integrity": "sha512-hXCqQL/15kMVDBuoBYpUnSYT8doDNwsjvm3jTefnXr+ytn294ySnT8NlsFHmTgKNjwpuFy7XVV8yTeLtNl/P6w==",
       "dev": true,
       "dependencies": {
-        "@vue/compiler-dom": "3.3.7",
-        "@vue/shared": "3.3.7"
+        "@vue/compiler-dom": "3.3.8",
+        "@vue/shared": "3.3.8"
       }
     },
     "node_modules/@vue/devtools-api": {
@@ -2866,65 +2883,65 @@
       "dev": true
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.3.7.tgz",
-      "integrity": "sha512-cZNVjWiw00708WqT0zRpyAgduG79dScKEPYJXq2xj/aMtk3SKvL3FBt2QKUlh6EHBJ1m8RhBY+ikBUzwc7/khg==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.3.8.tgz",
+      "integrity": "sha512-ctLWitmFBu6mtddPyOKpHg8+5ahouoTCRtmAHZAXmolDtuZXfjL2T3OJ6DL6ezBPQB1SmMnpzjiWjCiMYmpIuw==",
       "dev": true,
       "dependencies": {
-        "@vue/shared": "3.3.7"
+        "@vue/shared": "3.3.8"
       }
     },
     "node_modules/@vue/reactivity-transform": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.3.7.tgz",
-      "integrity": "sha512-APhRmLVbgE1VPGtoLQoWBJEaQk4V8JUsqrQihImVqKT+8U6Qi3t5ATcg4Y9wGAPb3kIhetpufyZ1RhwbZCIdDA==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.3.8.tgz",
+      "integrity": "sha512-49CvBzmZNtcHua0XJ7GdGifM8GOXoUMOX4dD40Y5DxI3R8OUhMlvf2nvgUAcPxaXiV5MQQ1Nwy09ADpnLQUqRw==",
       "dev": true,
       "dependencies": {
         "@babel/parser": "^7.23.0",
-        "@vue/compiler-core": "3.3.7",
-        "@vue/shared": "3.3.7",
+        "@vue/compiler-core": "3.3.8",
+        "@vue/shared": "3.3.8",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.30.5"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.3.7.tgz",
-      "integrity": "sha512-LHq9du3ubLZFdK/BP0Ysy3zhHqRfBn80Uc+T5Hz3maFJBGhci1MafccnL3rpd5/3wVfRHAe6c+PnlO2PAavPTQ==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.3.8.tgz",
+      "integrity": "sha512-qurzOlb6q26KWQ/8IShHkMDOuJkQnQcTIp1sdP4I9MbCf9FJeGVRXJFr2mF+6bXh/3Zjr9TDgURXrsCr9bfjUw==",
       "dev": true,
       "dependencies": {
-        "@vue/reactivity": "3.3.7",
-        "@vue/shared": "3.3.7"
+        "@vue/reactivity": "3.3.8",
+        "@vue/shared": "3.3.8"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.3.7.tgz",
-      "integrity": "sha512-PFQU1oeJxikdDmrfoNQay5nD4tcPNYixUBruZzVX/l0eyZvFKElZUjW4KctCcs52nnpMGO6UDK+jF5oV4GT5Lw==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.3.8.tgz",
+      "integrity": "sha512-Noy5yM5UIf9UeFoowBVgghyGGPIDPy1Qlqt0yVsUdAVbqI8eeMSsTqBtauaEoT2UFXUk5S64aWVNJN4MJ2vRdA==",
       "dev": true,
       "dependencies": {
-        "@vue/runtime-core": "3.3.7",
-        "@vue/shared": "3.3.7",
+        "@vue/runtime-core": "3.3.8",
+        "@vue/shared": "3.3.8",
         "csstype": "^3.1.2"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.3.7.tgz",
-      "integrity": "sha512-UlpKDInd1hIZiNuVVVvLgxpfnSouxKQOSE2bOfQpBuGwxRV/JqqTCyyjXUWiwtVMyeRaZhOYYqntxElk8FhBhw==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.3.8.tgz",
+      "integrity": "sha512-zVCUw7RFskvPuNlPn/8xISbrf0zTWsTSdYTsUTN1ERGGZGVnRxM2QZ3x1OR32+vwkkCm0IW6HmJ49IsPm7ilLg==",
       "dev": true,
       "dependencies": {
-        "@vue/compiler-ssr": "3.3.7",
-        "@vue/shared": "3.3.7"
+        "@vue/compiler-ssr": "3.3.8",
+        "@vue/shared": "3.3.8"
       },
       "peerDependencies": {
-        "vue": "3.3.7"
+        "vue": "3.3.8"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.7.tgz",
-      "integrity": "sha512-N/tbkINRUDExgcPTBvxNkvHGu504k8lzlNQRITVnm6YjOjwa4r0nnbd4Jb01sNpur5hAllyRJzSK5PvB9PPwRg==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.8.tgz",
+      "integrity": "sha512-8PGwybFwM4x8pcfgqEQFy70NaQxASvOC5DJwLQfpArw1UDfUXrJkdxD3BhVTMS+0Lef/TU7YO0Jvr0jJY8T+mw==",
       "dev": true
     },
     "node_modules/@vuetify/loader-shared": {
@@ -3545,12 +3562,30 @@
       }
     },
     "node_modules/cacache/node_modules/lru-cache": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.1.tgz",
-      "integrity": "sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.2.tgz",
+      "integrity": "sha512-Yj9mA8fPiVgOUpByoTZO5pNrcl5Yk37FcSHsUINpAsaBIEZIuqcCclDZJCVxqQShDsmYX8QG63svJiTbOATZwg==",
       "dev": true,
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
       "engines": {
         "node": "14 || >=16.14"
+      }
+    },
+    "node_modules/cacache/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/camelcase": {
@@ -3577,9 +3612,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001561",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001561.tgz",
-      "integrity": "sha512-NTt0DNoKe958Q0BE0j0c1V9jbUzhBxHIEJy7asmGrpE0yG63KTV7PLHPnK2E1O9RsQrQ081I3NLuXGS6zht3cw==",
+      "version": "1.0.30001562",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001562.tgz",
+      "integrity": "sha512-kfte3Hym//51EdX4239i+Rmp20EsLIYGdPkERegTgU19hQWCRhsRFGKHTliUlsry53tv17K7n077Kqa0WJU4ng==",
       "dev": true,
       "funding": [
         {
@@ -4204,12 +4239,6 @@
       "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
       "dev": true
     },
-    "node_modules/cuint": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/cuint/-/cuint-0.2.2.tgz",
-      "integrity": "sha512-d4ZVpCW31eWwCMe1YT3ur7mUDnTXbgwyzaL320DrcRT45rfjYxkt5QWLrmOJ+/UEAI2+fQgKe/fCjR8l4TpRgw==",
-      "dev": true
-    },
     "node_modules/data-uri-to-buffer": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-2.0.2.tgz",
@@ -4493,9 +4522,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.576",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.576.tgz",
-      "integrity": "sha512-yXsZyXJfAqzWk1WKryr0Wl0MN2D47xodPvEEwlVePBnhU5E7raevLQR+E6b9JAD3GfL/7MbAL9ZtWQQPcLx7wA==",
+      "version": "1.4.584",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.584.tgz",
+      "integrity": "sha512-rXCtDiXCBtfTfEegkthruCvyWZnr1/FCrUGY/nYQiF+lSZDmwQBDxp0rivZxV8trXb6cbgojhcSTW5xsDcHQ8g==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -4561,18 +4590,6 @@
       "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
       "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
       "dev": true
-    },
-    "node_modules/errno": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
-      "integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
-      "dev": true,
-      "dependencies": {
-        "prr": "~1.0.1"
-      },
-      "bin": {
-        "errno": "cli.js"
-      }
     },
     "node_modules/error-stack-parser-es": {
       "version": "0.1.1",
@@ -4740,9 +4757,9 @@
       "dev": true
     },
     "node_modules/fast-glob": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
-      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
       "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -5127,28 +5144,16 @@
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "dev": true
     },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+    "node_modules/global-directory": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-4.0.1.tgz",
+      "integrity": "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==",
       "dev": true,
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "ini": "4.1.1"
       },
       "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/global-dirs": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.1.tgz",
-      "integrity": "sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==",
-      "dev": true,
-      "dependencies": {
-        "ini": "2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -5271,10 +5276,13 @@
       }
     },
     "node_modules/hosted-git-info/node_modules/lru-cache": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.1.tgz",
-      "integrity": "sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.2.tgz",
+      "integrity": "sha512-Yj9mA8fPiVgOUpByoTZO5pNrcl5Yk37FcSHsUINpAsaBIEZIuqcCclDZJCVxqQShDsmYX8QG63svJiTbOATZwg==",
       "dev": true,
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
       "engines": {
         "node": "14 || >=16.14"
       }
@@ -5405,14 +5413,26 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-    "node_modules/image-meta": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/image-meta/-/image-meta-0.1.1.tgz",
-      "integrity": "sha512-+oXiHwOEPr1IE5zY0tcBLED/CYcre15J4nwL50x3o0jxWqEkyjrusiKP3YSU+tr9fvJp33ZcP5Gpj2295g3aEw==",
+    "node_modules/ignore-walk/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
       "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
       "engines": {
-        "node": ">=10.18.0"
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/image-meta": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/image-meta/-/image-meta-0.2.0.tgz",
+      "integrity": "sha512-ZBGjl0ZMEMeOC3Ns0wUF/5UdUmr3qQhBSCniT0LxOgGGIRHiNFOkMtIHB7EOznRU47V2AxPgiVP+s+0/UCU0Hg==",
+      "dev": true
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
@@ -5449,12 +5469,12 @@
       "dev": true
     },
     "node_modules/ini": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
-      "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.1.tgz",
+      "integrity": "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==",
       "dev": true,
       "engines": {
-        "node": ">=10"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/ioredis": {
@@ -5624,16 +5644,16 @@
       }
     },
     "node_modules/is-installed-globally": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.4.0.tgz",
-      "integrity": "sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-1.0.0.tgz",
+      "integrity": "sha512-K55T22lfpQ63N4KEN57jZUAaAYqYHEe8veb/TycJRk9DdSCLLcovXz/mL6mOnhQaZsQGwPhuFopdQIlqGSEjiQ==",
       "dev": true,
       "dependencies": {
-        "global-dirs": "^3.0.0",
-        "is-path-inside": "^3.0.2"
+        "global-directory": "^4.0.1",
+        "is-path-inside": "^4.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -5661,12 +5681,15 @@
       }
     },
     "node_modules/is-path-inside": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
-      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
       "dev": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-primitive": {
@@ -6525,13 +6548,13 @@
       }
     },
     "node_modules/magicast": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.0.tgz",
-      "integrity": "sha512-ZsEzw35h7xYoFlWHIyxU6zmH4sdwzdmY0DY4s/Lie/qKimeijz2jRw8/OV2248kt/y6FbvoTvGRKyB7y/Mpx8w==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.2.tgz",
+      "integrity": "sha512-Fjwkl6a0syt9TFN0JSYpOybxiMCkYNEeOTnOTNRbjphirLakznZXAqrXgj/7GG3D1dvETONNwrBfinvAbpunDg==",
       "dev": true,
       "dependencies": {
-        "@babel/parser": "^7.22.16",
-        "@babel/types": "^7.22.19",
+        "@babel/parser": "^7.23.3",
+        "@babel/types": "^7.23.3",
         "source-map-js": "^1.0.2"
       }
     },
@@ -6596,49 +6619,6 @@
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
       "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
       "dev": true
-    },
-    "node_modules/memory-fs": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
-      "integrity": "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==",
-      "dev": true,
-      "dependencies": {
-        "errno": "^0.1.3",
-        "readable-stream": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=4.3.0 <5.0.0 || >=5.10"
-      }
-    },
-    "node_modules/memory-fs/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "dev": true,
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/memory-fs/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
-    },
-    "node_modules/memory-fs/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -6735,18 +6715,15 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "node": ">=10"
       }
     },
     "node_modules/minipass": {
@@ -7296,6 +7273,21 @@
         "node": ">=16"
       }
     },
+    "node_modules/node-gyp/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/node-gyp/node_modules/nopt": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.0.tgz",
@@ -7554,28 +7546,28 @@
       }
     },
     "node_modules/nuxt": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/nuxt/-/nuxt-3.8.0.tgz",
-      "integrity": "sha512-ZnisJYx5AcUl7xlw18m6zfINBpNhld+ZF+jdTLRZxkLjKSFZeFMGqKxOR1jNVSmxfIXM/guK0uV9GPm6HK/z7g==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/nuxt/-/nuxt-3.8.1.tgz",
+      "integrity": "sha512-RSGO56Gv0x2f6AXWw4o4GoBaVdsD0qkPCjrX7Ud/jzH3cRJoyYMPuq/9AOLvf2o1ecZWl39j5elqJ4QHmggyOA==",
       "dev": true,
       "dependencies": {
         "@nuxt/devalue": "^2.0.2",
         "@nuxt/devtools": "^1.0.0",
-        "@nuxt/kit": "3.8.0",
-        "@nuxt/schema": "3.8.0",
+        "@nuxt/kit": "3.8.1",
+        "@nuxt/schema": "3.8.1",
         "@nuxt/telemetry": "^2.5.2",
         "@nuxt/ui-templates": "^1.3.1",
-        "@nuxt/vite-builder": "3.8.0",
-        "@unhead/dom": "^1.7.4",
-        "@unhead/ssr": "^1.7.4",
-        "@unhead/vue": "^1.7.4",
-        "@vue/shared": "^3.3.4",
-        "acorn": "8.10.0",
+        "@nuxt/vite-builder": "3.8.1",
+        "@unhead/dom": "^1.8.3",
+        "@unhead/ssr": "^1.8.3",
+        "@unhead/vue": "^1.8.3",
+        "@vue/shared": "^3.3.8",
+        "acorn": "8.11.2",
         "c12": "^1.5.1",
         "chokidar": "^3.5.3",
         "cookie-es": "^1.0.0",
-        "defu": "^6.1.2",
-        "destr": "^2.0.1",
+        "defu": "^6.1.3",
+        "destr": "^2.0.2",
         "devalue": "^4.3.2",
         "esbuild": "^0.19.5",
         "escape-string-regexp": "^5.0.0",
@@ -7584,12 +7576,12 @@
         "globby": "^13.2.2",
         "h3": "^1.8.2",
         "hookable": "^5.5.3",
-        "jiti": "^1.20.0",
+        "jiti": "^1.21.0",
         "klona": "^2.0.6",
         "knitwork": "^1.0.0",
         "magic-string": "^0.30.5",
         "mlly": "^1.4.2",
-        "nitropack": "^2.7.0",
+        "nitropack": "^2.7.2",
         "nuxi": "^3.9.1",
         "nypm": "^0.3.3",
         "ofetch": "^1.3.3",
@@ -7610,7 +7602,7 @@
         "unplugin": "^1.5.0",
         "unplugin-vue-router": "^0.7.0",
         "untyped": "^1.4.0",
-        "vue": "^3.3.4",
+        "vue": "^3.3.8",
         "vue-bundle-renderer": "^2.0.0",
         "vue-devtools-stub": "^0.1.0",
         "vue-router": "^4.2.5"
@@ -7633,18 +7625,6 @@
         "@types/node": {
           "optional": true
         }
-      }
-    },
-    "node_modules/nuxt/node_modules/acorn": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
-      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
-      "dev": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/nuxt/node_modules/estree-walker": {
@@ -7810,9 +7790,9 @@
       }
     },
     "node_modules/openai": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-4.18.0.tgz",
-      "integrity": "sha512-0C+waXoU7mvp/1QZzwnmPCkq4t02VJkjL1EXn0Pd7pFuTA0Y4y1LwzSZSiF/tpxw+Pr7diHVJjbfJ8QbdZnEcA==",
+      "version": "4.19.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.19.0.tgz",
+      "integrity": "sha512-cJbl0noZyAaXVKBTMMq6X5BAvP1pm2rWYDBnZes99NL+Zh5/4NmlAwyuhTZEru5SqGGZIoiYKeMPXy4bm9DI0w==",
       "dependencies": {
         "@types/node": "^18.11.18",
         "@types/node-fetch": "^2.6.4",
@@ -7834,16 +7814,16 @@
       "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw=="
     },
     "node_modules/openapi-typescript": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/openapi-typescript/-/openapi-typescript-6.7.0.tgz",
-      "integrity": "sha512-eoUfJwhnMEug7euZ1dATG7iRiDVsEROwdPkhLUDiaFjcClV4lzft9F0Ii0fYjULCPNIiWiFi0BqMpSxipuvAgQ==",
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/openapi-typescript/-/openapi-typescript-6.7.1.tgz",
+      "integrity": "sha512-Q3Ltt0KUm2smcPrsaR8qKmSwQ1KM4yGDJVoQdpYa0yvKPeN8huDx5utMT7DvwvJastHHzUxajjivK3WN2+fobg==",
       "dev": true,
       "dependencies": {
         "ansi-colors": "^4.1.3",
         "fast-glob": "^3.3.1",
         "js-yaml": "^4.1.0",
         "supports-color": "^9.4.0",
-        "undici": "^5.23.0",
+        "undici": "^5.27.2",
         "yargs-parser": "^21.1.1"
       },
       "bin": {
@@ -8075,10 +8055,13 @@
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.1.tgz",
-      "integrity": "sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.2.tgz",
+      "integrity": "sha512-Yj9mA8fPiVgOUpByoTZO5pNrcl5Yk37FcSHsUINpAsaBIEZIuqcCclDZJCVxqQShDsmYX8QG63svJiTbOATZwg==",
       "dev": true,
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
       "engines": {
         "node": "14 || >=16.14"
       }
@@ -8126,15 +8109,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/pify": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/pkg-dir": {
@@ -8284,55 +8258,6 @@
       },
       "peerDependencies": {
         "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-import": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
-      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
-      "dev": true,
-      "dependencies": {
-        "postcss-value-parser": "^4.0.0",
-        "read-cache": "^1.0.0",
-        "resolve": "^1.1.7"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.0.0"
-      }
-    },
-    "node_modules/postcss-import-resolver": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-import-resolver/-/postcss-import-resolver-2.0.0.tgz",
-      "integrity": "sha512-y001XYgGvVwgxyxw9J1a5kqM/vtmIQGzx34g0A0Oy44MFcy/ZboZw1hu/iN3VYFjSTRzbvd7zZJJz0Kh0AGkTw==",
-      "dev": true,
-      "dependencies": {
-        "enhanced-resolve": "^4.1.1"
-      }
-    },
-    "node_modules/postcss-import-resolver/node_modules/enhanced-resolve": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz",
-      "integrity": "sha512-Nv9m36S/vxpsI+Hc4/ZGRs0n9mXqSWGGq49zxb/cJfPAQMbUtttJAlNPS4AQzaBdw/pKskw5bMbekT/Y7W/Wlg==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "memory-fs": "^0.5.0",
-        "tapable": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-import-resolver/node_modules/tapable": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
-      "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/postcss-merge-longhand": {
@@ -8657,58 +8582,6 @@
         "postcss": "^8.2.15"
       }
     },
-    "node_modules/postcss-url": {
-      "version": "10.1.3",
-      "resolved": "https://registry.npmjs.org/postcss-url/-/postcss-url-10.1.3.tgz",
-      "integrity": "sha512-FUzyxfI5l2tKmXdYc6VTu3TWZsInayEKPbiyW+P6vmmIrrb4I6CGX0BFoewgYHLK+oIL5FECEK02REYRpBvUCw==",
-      "dev": true,
-      "dependencies": {
-        "make-dir": "~3.1.0",
-        "mime": "~2.5.2",
-        "minimatch": "~3.0.4",
-        "xxhashjs": "~0.2.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "postcss": "^8.0.0"
-      }
-    },
-    "node_modules/postcss-url/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/postcss-url/node_modules/mime": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz",
-      "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==",
-      "dev": true,
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/postcss-url/node_modules/minimatch": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
-      "integrity": "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
@@ -8813,12 +8686,6 @@
       "integrity": "sha512-/XJ368cyBJ7fzLMwLKv1e4vLxOju2MNAIokcr7meSaNcVbWz/CPcW22cP04mwxOErdA5mwjA8Q6w/cdAQxVn7Q==",
       "dev": true
     },
-    "node_modules/prr": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-      "integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
-      "dev": true
-    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -8880,15 +8747,6 @@
         "flat": "^5.0.2"
       }
     },
-    "node_modules/read-cache": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
-      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
-      "dev": true,
-      "dependencies": {
-        "pify": "^2.3.0"
-      }
-    },
     "node_modules/read-package-json": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-7.0.0.tgz",
@@ -8939,6 +8797,21 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/read-package-json/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -8960,18 +8833,6 @@
       "dev": true,
       "dependencies": {
         "minimatch": "^5.1.0"
-      }
-    },
-    "node_modules/readdir-glob/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/readdirp": {
@@ -9373,9 +9234,9 @@
       "optional": true
     },
     "node_modules/scule": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/scule/-/scule-1.0.0.tgz",
-      "integrity": "sha512-4AsO/FrViE/iDNEPaAQlb77tf0csuq27EsVpy6ett584EcRTp6pTDLoGWVxCD77y5iU5FauOvhsI4o1APwPoSQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/scule/-/scule-1.1.0.tgz",
+      "integrity": "sha512-vRUjqhyM/YWYzT+jsMk6tnl3NkY4A4soJ8uyh3O6Um+JXEQL9ozUCe7pqrxn3CSKokw0hw3nFStfskzpgYwR0g==",
       "dev": true
     },
     "node_modules/selfsigned": {
@@ -9782,9 +9643,9 @@
       }
     },
     "node_modules/std-env": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.4.3.tgz",
-      "integrity": "sha512-f9aPhy8fYBuMN+sNfakZV18U39PbalgjXG3lLB9WkaYTxijru61wb57V9wxxNthXM5Sd88ETBWi29qLAsHO52Q==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.5.0.tgz",
+      "integrity": "sha512-JGUEaALvL0Mf6JCfYnJOTcobY+Nc7sG/TemDRBqCA0wEr4DER7zDchaaixTlmOxAjG1uRJmX82EQcxwTQTkqVA==",
       "dev": true
     },
     "node_modules/stoppable": {
@@ -9798,9 +9659,9 @@
       }
     },
     "node_modules/streamx": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.2.tgz",
-      "integrity": "sha512-b62pAV/aeMjUoRN2C/9F0n+G8AfcJjNC0zw/ZmOHeFsIe4m4GzjVW9m6VHXVjk536NbdU9JRwKMJRfkc+zUFTg==",
+      "version": "2.15.5",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.5.tgz",
+      "integrity": "sha512-9thPGMkKC2GctCzyCUjME3yR03x2xNo0GPKGkRw2UMYN+gqWa9uqpyNWhmsNCutU5zHmkUum0LsCRQTXUgUCAg==",
       "dev": true,
       "dependencies": {
         "fast-fifo": "^1.1.0",
@@ -9941,16 +9802,16 @@
       "dev": true
     },
     "node_modules/svgo": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.0.2.tgz",
-      "integrity": "sha512-Z706C1U2pb1+JGP48fbazf3KxHrWOsLme6Rv7imFBn5EnuanDW1GPaA/P1/dvObE670JDePC3mnj0k0B7P0jjQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.0.3.tgz",
+      "integrity": "sha512-X4UZvLhOglD5Xrp834HzGHf8RKUW0Ahigg/08yRO1no9t2NxffOkMiQ0WmaMIbaGlVTlSst2zWANsdhz5ybXgA==",
       "dev": true,
       "dependencies": {
         "@trysound/sax": "0.2.0",
         "commander": "^7.2.0",
         "css-select": "^5.1.0",
         "css-tree": "^2.2.1",
-        "csso": "^5.0.5",
+        "csso": "5.0.5",
         "picocolors": "^1.0.0"
       },
       "bin": {
@@ -10168,9 +10029,9 @@
       }
     },
     "node_modules/ufo": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.3.1.tgz",
-      "integrity": "sha512-uY/99gMLIOlJPwATcMVYfqDSxUR9//AUcgZMzwfSTJPDKzA1S8mX4VLqa+fiAtveraQUBCz4FFcwVZBGbwBXIw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.3.2.tgz",
+      "integrity": "sha512-o+ORpgGwaYQXgqGDwd+hkS4PuZ3QnmqMMxRuajK/a38L6fTpcE5GPIfrf+L/KemFzfUpeUQc1rRS1iDBozvnFA==",
       "dev": true
     },
     "node_modules/ultrahtml": {
@@ -10252,34 +10113,22 @@
       }
     },
     "node_modules/unimport": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/unimport/-/unimport-3.4.0.tgz",
-      "integrity": "sha512-M/lfFEgufIT156QAr/jWHLUn55kEmxBBiQsMxvRSIbquwmeJEyQYgshHDEvQDWlSJrVOOTAgnJ3FvlsrpGkanA==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/unimport/-/unimport-3.5.0.tgz",
+      "integrity": "sha512-0Ei1iTeSYxs7oxxUf79/KaBc2dPjZxe7qdVpw7yIz5YcdTZjmBYO6ToLDW+fX9QOHiueZ3xtwb5Z/wqaSfXx6A==",
       "dev": true,
       "dependencies": {
-        "@rollup/pluginutils": "^5.0.4",
+        "@rollup/pluginutils": "^5.0.5",
         "escape-string-regexp": "^5.0.0",
-        "fast-glob": "^3.3.1",
-        "local-pkg": "^0.4.3",
-        "magic-string": "^0.30.3",
+        "fast-glob": "^3.3.2",
+        "local-pkg": "^0.5.0",
+        "magic-string": "^0.30.5",
         "mlly": "^1.4.2",
         "pathe": "^1.1.1",
         "pkg-types": "^1.0.3",
         "scule": "^1.0.0",
         "strip-literal": "^1.3.0",
         "unplugin": "^1.5.0"
-      }
-    },
-    "node_modules/unimport/node_modules/local-pkg": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.4.3.tgz",
-      "integrity": "sha512-SFppqq5p42fe2qcZQqqEOiVRXl+WCP1MdT6k7BDEW1j++sp5fIY+/fdRQitvKgB5BrBcmrs5m/L0v2FrU5MY1g==",
-      "dev": true,
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/unique-filename": {
@@ -10369,34 +10218,35 @@
       }
     },
     "node_modules/unstorage": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.9.0.tgz",
-      "integrity": "sha512-VpD8ZEYc/le8DZCrny3bnqKE4ZjioQxBRnWE+j5sGNvziPjeDlaS1NaFFHzl/kkXaO3r7UaF8MGQrs14+1B4pQ==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.10.1.tgz",
+      "integrity": "sha512-rWQvLRfZNBpF+x8D3/gda5nUCQL2PgXy2jNG4U7/Rc9BGEv9+CAJd0YyGCROUBKs9v49Hg8huw3aih5Bf5TAVw==",
       "dev": true,
       "dependencies": {
         "anymatch": "^3.1.3",
         "chokidar": "^3.5.3",
-        "destr": "^2.0.1",
-        "h3": "^1.7.1",
+        "destr": "^2.0.2",
+        "h3": "^1.8.2",
         "ioredis": "^5.3.2",
-        "listhen": "^1.2.2",
-        "lru-cache": "^10.0.0",
+        "listhen": "^1.5.5",
+        "lru-cache": "^10.0.2",
         "mri": "^1.2.0",
-        "node-fetch-native": "^1.2.0",
-        "ofetch": "^1.1.1",
-        "ufo": "^1.2.0"
+        "node-fetch-native": "^1.4.1",
+        "ofetch": "^1.3.3",
+        "ufo": "^1.3.1"
       },
       "peerDependencies": {
         "@azure/app-configuration": "^1.4.1",
-        "@azure/cosmos": "^3.17.3",
+        "@azure/cosmos": "^4.0.0",
         "@azure/data-tables": "^13.2.2",
-        "@azure/identity": "^3.2.3",
+        "@azure/identity": "^3.3.2",
         "@azure/keyvault-secrets": "^4.7.0",
-        "@azure/storage-blob": "^12.14.0",
-        "@capacitor/preferences": "^5.0.0",
-        "@planetscale/database": "^1.8.0",
-        "@upstash/redis": "^1.22.0",
-        "@vercel/kv": "^0.2.2",
+        "@azure/storage-blob": "^12.16.0",
+        "@capacitor/preferences": "^5.0.6",
+        "@netlify/blobs": "^6.2.0",
+        "@planetscale/database": "^1.11.0",
+        "@upstash/redis": "^1.23.4",
+        "@vercel/kv": "^0.2.3",
         "idb-keyval": "^6.2.1"
       },
       "peerDependenciesMeta": {
@@ -10421,6 +10271,9 @@
         "@capacitor/preferences": {
           "optional": true
         },
+        "@netlify/blobs": {
+          "optional": true
+        },
         "@planetscale/database": {
           "optional": true
         },
@@ -10436,10 +10289,13 @@
       }
     },
     "node_modules/unstorage/node_modules/lru-cache": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.1.tgz",
-      "integrity": "sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.2.tgz",
+      "integrity": "sha512-Yj9mA8fPiVgOUpByoTZO5pNrcl5Yk37FcSHsUINpAsaBIEZIuqcCclDZJCVxqQShDsmYX8QG63svJiTbOATZwg==",
       "dev": true,
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
       "engines": {
         "node": "14 || >=16.14"
       }
@@ -10812,9 +10668,9 @@
       }
     },
     "node_modules/vite-plugin-inspect": {
-      "version": "0.7.41",
-      "resolved": "https://registry.npmjs.org/vite-plugin-inspect/-/vite-plugin-inspect-0.7.41.tgz",
-      "integrity": "sha512-gASdFRO4CHDQF8qAk9LZEJyzlIJM4bFvDn7hz0e2r1PS6uq+yukd8+jHctOAbvCceQoTS5iDAgd4/mWcGWYoMw==",
+      "version": "0.7.42",
+      "resolved": "https://registry.npmjs.org/vite-plugin-inspect/-/vite-plugin-inspect-0.7.42.tgz",
+      "integrity": "sha512-JCyX86wr3siQc+p9Kd0t8VkFHAJag0RaQVIpdFGSv5FEaePEVB6+V/RGtz2dQkkGSXQzRWrPs4cU3dRKg32bXw==",
       "dev": true,
       "dependencies": {
         "@antfu/utils": "^0.7.6",
@@ -11384,16 +11240,16 @@
       "dev": true
     },
     "node_modules/vue": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.3.7.tgz",
-      "integrity": "sha512-YEMDia1ZTv1TeBbnu6VybatmSteGOS3A3YgfINOfraCbf85wdKHzscD6HSS/vB4GAtI7sa1XPX7HcQaJ1l24zA==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.3.8.tgz",
+      "integrity": "sha512-5VSX/3DabBikOXMsxzlW8JyfeLKlG9mzqnWgLQLty88vdZL7ZJgrdgBOmrArwxiLtmS+lNNpPcBYqrhE6TQW5w==",
       "dev": true,
       "dependencies": {
-        "@vue/compiler-dom": "3.3.7",
-        "@vue/compiler-sfc": "3.3.7",
-        "@vue/runtime-dom": "3.3.7",
-        "@vue/server-renderer": "3.3.7",
-        "@vue/shared": "3.3.7"
+        "@vue/compiler-dom": "3.3.8",
+        "@vue/compiler-sfc": "3.3.8",
+        "@vue/runtime-dom": "3.3.8",
+        "@vue/server-renderer": "3.3.8",
+        "@vue/shared": "3.3.8"
       },
       "peerDependencies": {
         "typescript": "*"
@@ -11435,9 +11291,9 @@
       }
     },
     "node_modules/vuetify": {
-      "version": "3.3.23",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.3.23.tgz",
-      "integrity": "sha512-EVEFvDyKr/HK2+hQJyhQSjIDULDaBi9vfgAAB0ekm+2Tvc8AkaDwb7VK44R2eilGFGpju6iN52FV7Uasj8SmIg==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.4.1.tgz",
+      "integrity": "sha512-mF/vKa923F/90JVZnF6xZVoEY5aWbtDt0feh6CFOh6PFmZ7fRUVWIvhlQcH4zwHMXF+HpTL9Mer1CwOpi4D4oQ==",
       "dev": true,
       "engines": {
         "node": "^12.20 || >=14.13"
@@ -11449,7 +11305,7 @@
       "peerDependencies": {
         "typescript": ">=4.7",
         "vite-plugin-vuetify": "^1.0.0-alpha.12",
-        "vue": "^3.2.0",
+        "vue": "^3.3.0",
         "vue-i18n": "^9.0.0",
         "webpack-plugin-vuetify": "^2.0.0-alpha.11"
       },
@@ -12139,15 +11995,6 @@
       "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.0.2.tgz",
       "integrity": "sha512-ibF0Or+FivM9lNrg+HGJfVX8WJqgo+kCLDc4vx6xMeTce7Aj+DLttKbxxRR/gNLSAelRc1omAPlJ77N/Jem07A==",
       "dev": true
-    },
-    "node_modules/xxhashjs": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/xxhashjs/-/xxhashjs-0.2.2.tgz",
-      "integrity": "sha512-AkTuIuVTET12tpsVIQo+ZU6f/qDmKuRUcjaqR+OIvm+aCBsZ95i7UVY5WJ9TMsSaZ0DA2WxoZ4acu0sPH+OKAw==",
-      "dev": true,
-      "dependencies": {
-        "cuint": "^0.2.2"
-      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "NITRO_PRESET=cloudflare-module nuxt build",
     "dev": "nuxt dev",
-    "preview": "npx wrangler dev .output/server/index.mjs --site .output/public --remote",
+    "preview": "nuxt preview",
     "postinstall": "nuxt prepare"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -4,12 +4,9 @@
   "type": "module",
   "scripts": {
     "build": "NITRO_PRESET=cloudflare-module nuxt build",
-    "dev": "npx wrangler dev .output/server/index.mjs --site .output/public --remote",
-    "generate": "nuxt generate",
-    "preview": "nuxt preview",
-    "postinstall": "nuxt prepare",
-    "pages:dev": "wrangler pages dev --compatibility-date=2023-10-30 --proxy 3000 & npm run dev",
-    "pages:deploy": "npm run build && wrangler pages deploy ./dist"
+    "dev": "nuxt dev",
+    "preview": "npx wrangler dev .output/server/index.mjs --site .output/public --remote",
+    "postinstall": "nuxt prepare"
   },
   "devDependencies": {
     "@nuxt/devtools": "latest",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "NITRO_PRESET=cloudflare-pages nuxt build",
-    "dev": "nuxt dev",
+    "build": "NITRO_PRESET=cloudflare-module nuxt build",
+    "dev": "npx wrangler dev .output/server/index.mjs --site .output/public --remote",
     "generate": "nuxt generate",
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare",

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -133,7 +133,7 @@ const askPhilosopher = async (e:Event) => {
       content: userQuestion.value || questionPlaceholder.value
     });
     userQuestion.value = '';
-    const questionResponse = await fetch(`http://localhost:8788/chat/`, {
+    const questionResponse = await fetch(`/api/chat`, {
       method: 'POST',
       body: JSON.stringify({
         person: selectedPhilosopher.value,

--- a/server/api/chat.post.ts
+++ b/server/api/chat.post.ts
@@ -20,6 +20,7 @@ export default defineEventHandler(async (event) => {
 
   const openAIModel = new ChatOpenAI({
     modelName: "gpt-3.5-turbo",
+    openAIApiKey: process.env.OPENAI_API_KEY,
   });
 
   const extractionPrompt = ChatPromptTemplate.fromMessages([
@@ -28,7 +29,7 @@ export default defineEventHandler(async (event) => {
     new MessagesPlaceholder('history'),
     ["human", "What domain of knowledge would be most helpful in answering the following question? Try to keep answers to one word:\n{input}"],
   ]);
-  
+
   const answerPrompt = ChatPromptTemplate.fromMessages([
     ["system", `You are an expert in {topic}. Be concise, kind, and helpful.
 Format your answers to be readable in a chat interface, and logically split your answer into paragraphs for readability.`
@@ -42,8 +43,8 @@ Format your answers to be readable in a chat interface, and logically split your
   });
 
   const chain = RunnableSequence.from([
-    RunnablePassthrough.assign({ 
-      topic: extractionPrompt.pipe(openAIModel).pipe(new StringOutputParser()) 
+    RunnablePassthrough.assign({
+      topic: extractionPrompt.pipe(openAIModel).pipe(new StringOutputParser())
     }),
     answerPrompt,
     cloudflareModel,

--- a/server/api/test.ts
+++ b/server/api/test.ts
@@ -1,0 +1,8 @@
+export default defineEventHandler((event) => {
+  return {
+    'event.context.cloudflare':  event.context.cloudflare,
+    'event.context.cloudflare.env.VECTORIZE_INDEX':  event.context.cloudflare.env.VECTORIZE_INDEX,
+    'process.env.VECTORIZE_INDEX': process.env.VECTORIZE_INDEX,
+    'import.meta.env.VECTORIZE_INDEX': import.meta.env.VECTORIZE_INDEX,
+  }
+})

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,6 +1,6 @@
 name = "langchain-worker"
-main = "src/worker.js"
-compatibility_date = "2023-05-24"
+main = "./.output/server/index.mjs"
+compatibility_date = "2023-11-15"
 compatibility_flags = [ "nodejs_compat" ]
 
 [[vectorize]]


### PR DESCRIPTION
Main change is using `cloudflare_module` preset instead of `cloudflare_pages` as `wrangler pages dev` seems not supporting `--remote` flag that is essential for supporting vecotrize API today.

Changes:
- git ignored local `.wrangler` dir
- Set `nitro.minify: false` to allow easier debugging
- Updated `build` command and manual `preview` to use `--remote`
- Updated `wrangler.toml` with nuxt valid entry and more recent compatibility date
- Added `/api/test` endpoint for debugging
- Add `.dev.vars.example` with introductions
- Update README with instructions

<img width="1245" alt="image" src="https://github.com/jacoblee93/langchain-nuxt-cloudflare-template/assets/5158436/bccbbc78-1606-4f9b-acfb-69e7f6f4a1ac">
